### PR TITLE
add notes endpoint

### DIFF
--- a/lib/wlist.rb
+++ b/lib/wlist.rb
@@ -16,8 +16,14 @@ OPTIONS_PARSER = OptionParser.new do |opts|
   opts.on("-j ID", "--list-id ID", Integer, "Object identifier") do |v|
     OPTIONS[:list_id] = v
   end
+  opts.on("-k ID", "--task-id ID", Integer, "Object identifier") do |v|
+    OPTIONS[:task_id] = v
+  end
   opts.on("-t TITLE", "--title TITLE", "Title for a task") do |v|
     OPTIONS[:title] = v
+  end
+  opts.on("-n CONTENT", "--content CONTENT", "Content for a note") do |v|
+    OPTIONS[:content] = v
   end
   opts.on("-u URL", "--url URL", "Webhook URL") do |v|
     OPTIONS[:url] = v

--- a/libexec/wlist-list:notes
+++ b/libexec/wlist-list:notes
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require "#{File.dirname(__FILE__)}/../lib/wlist.rb"
+
+parse_options
+response = get("notes?list_id=#{OPTIONS[:id]}")
+puts JSON.pretty_generate(response)

--- a/libexec/wlist-note
+++ b/libexec/wlist-note
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require "#{File.dirname(__FILE__)}/../lib/wlist.rb"
+
+parse_options
+response = get("notes/#{OPTIONS[:id]}")
+puts JSON.pretty_generate(response)

--- a/libexec/wlist-note:create
+++ b/libexec/wlist-note:create
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+require "#{File.dirname(__FILE__)}/../lib/wlist.rb"
+
+parse_options
+
+if !STDIN.tty?
+  data = JSON.parse(ARGF.read)
+else
+  data = {}
+end
+
+data['task_id'] = OPTIONS[:task_id] if OPTIONS[:task_id]
+data['content'] = OPTIONS[:content] if OPTIONS[:content]
+
+response = post("notes", data)
+puts JSON.pretty_generate(response)

--- a/libexec/wlist-note:delete
+++ b/libexec/wlist-note:delete
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require "#{File.dirname(__FILE__)}/../lib/wlist.rb"
+
+parse_options
+response = delete("notes/#{OPTIONS[:id]}?revision=#{OPTIONS[:revision]}")
+puts JSON.pretty_generate(response) if response

--- a/libexec/wlist-note:update
+++ b/libexec/wlist-note:update
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require "#{File.dirname(__FILE__)}/../lib/wlist.rb"
+
+parse_options
+
+if !STDIN.tty?
+  data = JSON.parse(ARGF.read)
+else
+  data = {}
+end
+
+id = data['id'] || OPTIONS[:id] # fail if neither?
+data['revision'] = OPTIONS[:revision] if OPTIONS[:revision]
+data['content'] = OPTIONS[:content] if OPTIONS[:content]
+
+response = patch("notes/#{id}", data)
+puts JSON.pretty_generate(response)

--- a/libexec/wlist-task:notes
+++ b/libexec/wlist-task:notes
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require "#{File.dirname(__FILE__)}/../lib/wlist.rb"
+
+parse_options
+response = get("notes?task_id=#{OPTIONS[:id]}")
+puts JSON.pretty_generate(response)


### PR DESCRIPTION
I was messing around with the wlist tool a little bit to get to know the API and decided to implement this issue.

To remain consistent two more command line options needed to be added. I chose `-k` for `:task_id` and `-n` for `:content`.

Commands added:

```
wlist list:notes -i <list-id>
wlist task:notes -i <task-id>
wlist note -i <note-id>
wlist note:create -k <task-id> -n <content>
wlist note:update -i <note-id> -r <revision> -n <content>
wlist note:delete -i <note-id> -r <revision>
```

closes #6
